### PR TITLE
Fix FastCos

### DIFF
--- a/distance.go
+++ b/distance.go
@@ -45,7 +45,7 @@ func FastSine(x float64) float64 {
 // FastCos calculates cosinus from sinus
 func FastCos(x float64) float64 {
 	x += math.Pi / 2.0
-	if x > math.Pi {
+	for x > math.Pi {
 		x -= 2 * math.Pi
 	}
 


### PR DESCRIPTION
If a y coordinate gets too big, then FastSine will throw a "panic out of range";  the true source stems from the caller `FastCos` where it does not reduce `x` enough. Fix is simple. Change `if` to `for`.

Refer to issue #8  for more info.